### PR TITLE
Update to current KaTeX version

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
     <title>Symbols and Functions in KaTeX</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta id="viewport" name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="//khan.github.io/KaTeX/bower_components/katex/dist/katex.min.css">
-    <script src="//khan.github.io/KaTeX/bower_components/katex/dist/katex.min.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/katex@0.9.0/dist/katex.min.css">
+    <script src="https://unpkg.com/katex@0.9.0/dist/katex.min.js"></script>
     <script type="text/javascript" src="dist/js/app-bundle.js" charset="utf-8"></script>
   </head>
   <body>

--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
     <title>Symbols and Functions in KaTeX</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta id="viewport" name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <link rel="stylesheet" href="https://unpkg.com/katex@0.9.0/dist/katex.min.css">
-    <script src="https://unpkg.com/katex@0.9.0/dist/katex.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/katex@0.9.0/dist/katex.min.js"></script>
     <script type="text/javascript" src="dist/js/app-bundle.js" charset="utf-8"></script>
   </head>
   <body>


### PR DESCRIPTION
This PR updates to the current KaTeX version and CDN. Since Bower is deprecated, KaTeX is now using`unpkg`.